### PR TITLE
Create internal methods only once

### DIFF
--- a/webkitAudioContextMonkeyPatch.js
+++ b/webkitAudioContextMonkeyPatch.js
@@ -61,64 +61,75 @@ OscillatorNode.setWaveTable() is aliased to setPeriodicWave().
   if (window.hasOwnProperty('AudioContext') /*&& !window.hasOwnProperty('webkitAudioContext') */) {
     window.webkitAudioContext = AudioContext;
 
-    AudioContext.prototype.internal_createGain = AudioContext.prototype.createGain;
-    AudioContext.prototype.createGain = function() { 
-      var node = this.internal_createGain();
-      fixSetTarget(node.gain);
-      return node;
-    };
+    if (!AudioContext.prototype.hasOwnProperty('internal_createGain')){
+      AudioContext.prototype.internal_createGain = AudioContext.prototype.createGain;
+      AudioContext.prototype.createGain = function() { 
+        var node = this.internal_createGain();
+        fixSetTarget(node.gain);
+        return node;
+      };
+    }
 
-    AudioContext.prototype.internal_createDelay = AudioContext.prototype.createDelay;
-    AudioContext.prototype.createDelay = function() { 
-      var node = this.internal_createDelay();
-      fixSetTarget(node.delayTime);
-      return node;
-    };
+    if (!AudioContext.prototype.hasOwnProperty('internal_createDelay')){
+      AudioContext.prototype.internal_createDelay = AudioContext.prototype.createDelay;
+      AudioContext.prototype.createDelay = function() { 
+        var node = this.internal_createDelay();
+        fixSetTarget(node.delayTime);
+        return node;
+      };
+    }
 
-    AudioContext.prototype.internal_createBufferSource = AudioContext.prototype.createBufferSource;
-    AudioContext.prototype.createBufferSource = function() { 
-      var node = this.internal_createBufferSource();
-      if (!node.noteOn)
-        node.noteOn = node.start; 
-      if (!node.noteGrainOn)
-        node.noteGrainOn = node.start;
-      if (!node.noteOff)
-        node.noteOff = node.stop;
-      fixSetTarget(node.playbackRate);
-      return node;
-    };
+    if (!AudioContext.prototype.hasOwnProperty('internal_createBufferSource')){
+      AudioContext.prototype.internal_createBufferSource = AudioContext.prototype.createBufferSource;
+      AudioContext.prototype.createBufferSource = function() { 
+        var node = this.internal_createBufferSource();
+        if (!node.noteOn)
+          node.noteOn = node.start; 
+        if (!node.noteGrainOn)
+          node.noteGrainOn = node.start;
+        if (!node.noteOff)
+          node.noteOff = node.stop;
+        fixSetTarget(node.playbackRate);
+        return node;
+      };
+    }
 
-    AudioContext.prototype.internal_createDynamicsCompressor = AudioContext.prototype.createDynamicsCompressor;
-    AudioContext.prototype.createDynamicsCompressor = function() { 
-      var node = this.internal_createDynamicsCompressor();
-      fixSetTarget(node.threshold);
-      fixSetTarget(node.knee);
-      fixSetTarget(node.ratio);
-      fixSetTarget(node.reduction);
-      fixSetTarget(node.attack);
-      fixSetTarget(node.release);
-      return node;
-    };
+    if (!AudioContext.prototype.hasOwnProperty('internal_createDynamicsCompressor')){
+      AudioContext.prototype.internal_createDynamicsCompressor = AudioContext.prototype.createDynamicsCompressor;
+      AudioContext.prototype.createDynamicsCompressor = function() { 
+        var node = this.internal_createDynamicsCompressor();
+        fixSetTarget(node.threshold);
+        fixSetTarget(node.knee);
+        fixSetTarget(node.ratio);
+        fixSetTarget(node.reduction);
+        fixSetTarget(node.attack);
+        fixSetTarget(node.release);
+        return node;
+      };
+    }
 
-    AudioContext.prototype.internal_createBiquadFilter = AudioContext.prototype.createBiquadFilter;
-    AudioContext.prototype.createBiquadFilter = function() { 
-      var node = this.internal_createBiquadFilter();
-      fixSetTarget(node.frequency);
-      fixSetTarget(node.detune);
-      fixSetTarget(node.Q);
-      fixSetTarget(node.gain);
-      var enumValues = ['LOWPASS', 'HIGHPASS', 'BANDPASS', 'LOWSHELF', 'HIGHSHELF', 'PEAKING', 'NOTCH', 'ALLPASS'];
-      for (var i = 0; i < enumValues.length; ++i) {
-        var enumValue = enumValues[i];
-        var newEnumValue = enumValue.toLowerCase();
-        if (!node.hasOwnProperty(enumValue)) {
-          node[enumValue] = newEnumValue;
+    if (!AudioContext.prototype.hasOwnProperty('internal_createBiquadFilter')){
+      AudioContext.prototype.internal_createBiquadFilter = AudioContext.prototype.createBiquadFilter;
+      AudioContext.prototype.createBiquadFilter = function() { 
+        var node = this.internal_createBiquadFilter();
+        fixSetTarget(node.frequency);
+        fixSetTarget(node.detune);
+        fixSetTarget(node.Q);
+        fixSetTarget(node.gain);
+        var enumValues = ['LOWPASS', 'HIGHPASS', 'BANDPASS', 'LOWSHELF', 'HIGHSHELF', 'PEAKING', 'NOTCH', 'ALLPASS'];
+        for (var i = 0; i < enumValues.length; ++i) {
+          var enumValue = enumValues[i];
+          var newEnumValue = enumValue.toLowerCase();
+          if (!node.hasOwnProperty(enumValue)) {
+            node[enumValue] = newEnumValue;
+          }
         }
-      }
-      return node;
-    };
+        return node;
+      };
+    }
 
-    if (AudioContext.prototype.hasOwnProperty( 'createOscillator' )) {
+    if (!AudioContext.prototype.hasOwnProperty('internal_createOscillator') &&
+         AudioContext.prototype.hasOwnProperty('createOscillator')) {
       AudioContext.prototype.internal_createOscillator = AudioContext.prototype.createOscillator;
       AudioContext.prototype.createOscillator = function() { 
         var node = this.internal_createOscillator();
@@ -143,24 +154,26 @@ OscillatorNode.setWaveTable() is aliased to setPeriodicWave().
       };
     }
 
-    AudioContext.prototype.internal_createPanner = AudioContext.prototype.createPanner;
-    AudioContext.prototype.createPanner = function() {
-      var node = this.internal_createPanner();
-      var enumValues = {
-        'EQUALPOWER': 'equalpower',
-        'HRTF': 'HRTF',
-        'LINEAR_DISTANCE': 'linear',
-        'INVERSE_DISTANCE': 'inverse',
-        'EXPONENTIAL_DISTANCE': 'exponential',
-      };
-      for (var enumValue in enumValues) {
-        var newEnumValue = enumValues[enumValue];
-        if (!node.hasOwnProperty(enumValue)) {
-          node[enumValue] = newEnumValue;
+    if (!AudioContext.prototype.hasOwnProperty('internal_createPanner') {
+      AudioContext.prototype.internal_createPanner = AudioContext.prototype.createPanner;
+      AudioContext.prototype.createPanner = function() {
+        var node = this.internal_createPanner();
+        var enumValues = {
+          'EQUALPOWER': 'equalpower',
+          'HRTF': 'HRTF',
+          'LINEAR_DISTANCE': 'linear',
+          'INVERSE_DISTANCE': 'inverse',
+          'EXPONENTIAL_DISTANCE': 'exponential',
+        };
+        for (var enumValue in enumValues) {
+          var newEnumValue = enumValues[enumValue];
+          if (!node.hasOwnProperty(enumValue)) {
+            node[enumValue] = newEnumValue;
+          }
         }
-      }
-      return node;
-    };
+        return node;
+      };
+    }
 
     if (!AudioContext.prototype.hasOwnProperty('createGainNode'))
       AudioContext.prototype.createGainNode = AudioContext.prototype.createGain;


### PR DESCRIPTION
Hi there,

I've noted that if for some reason the library is added more than once it will point the internal create methods to the create ones and when they are used it will get in an infinite loop.

It is an misuse case of the patch, but I've made this proposal with a check for if the internal methods are already created so you never get the issue.
